### PR TITLE
Add edit_global_item translation

### DIFF
--- a/shopping-list-app/script.js
+++ b/shopping-list-app/script.js
@@ -30,6 +30,7 @@ const translations = {
         close: "Close",
         manage_items: "Manage Items",
         rename_list: "Rename",
+        edit_global_item: "Edit",
         delete_list: "Delete",
         category_produce: "Produce",
         category_dairy: "Dairy",
@@ -101,6 +102,7 @@ const translations = {
         close: "סגור",
         manage_items: "ניהול פריטים",
         rename_list: "שנה שם",
+        edit_global_item: "ערוך",
         delete_list: "מחק",
         category_produce: "ירקות ופירות",
         category_dairy: "מוצרי חלב",
@@ -512,7 +514,7 @@ function renderGlobalItems() {
         li.appendChild(info);
         // Edit button
         const editBtn = document.createElement('button');
-        editBtn.textContent = t.rename_list;
+        editBtn.textContent = t.edit_global_item;
         editBtn.addEventListener('click', () => openGlobalItemModal(item.id));
         li.appendChild(editBtn);
         // Delete button


### PR DESCRIPTION
## Summary
- support `edit_global_item` translation in English and Hebrew
- use the new translation when rendering global item edit buttons

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_688893830e388325ab7da7a8a02a4e75