### PR TITLE
Fix WebSocket loop

### DIFF
--- a/shopping-list-app/script.js
+++ b/shopping-list-app/script.js
@@ -1457,8 +1457,10 @@ window.onRemoteDataUpdated = function(remoteData) {
     data.categories = data.categories || [];
     data.archivedLists = data.archivedLists || [];
     data.receipts = data.receipts || [];
-    // Save the remote data to local persistence as well
-    window.DataService.saveData(data);
+    // DataService.initSocket() already persisted the remote data to
+    // localStorage when it received the event. Avoid saving again here
+    // to prevent an update loop that would broadcast the data back to
+    // the server and trigger another 'dataUpdated' event.
     // Update UI
     renderLists();
     renderSummary();


### PR DESCRIPTION
## Summary
- prevent infinite loop when receiving `dataUpdated` events

## Testing
- `node server/server.js > /tmp/server.log 2>&1 &`

------
https://chatgpt.com/codex/tasks/task_e_68889732fbec8325b7e747de7979fb56