### PR TITLE
feat: sync server cache with firestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a simple shopping list web application and a small Node
 ## Project Structure
 
 - **shopping-list-app/** – HTML, CSS and JS for the client application.
-- **server/** – Express server that stores data in `data.json` and serves the frontend files.
+- **server/** – Express server that stores data in Firestore and serves the frontend files.
 - **package-lock.json** – placeholder for the root (no dependencies).
 
 ## Getting Started
@@ -16,7 +16,7 @@ This repository contains a simple shopping list web application and a small Node
    cd server
    npm install
    ```
-3. Start the server:
+3. Provide Firestore credentials via the `FIREBASE_SERVICE_ACCOUNT_JSON` environment variable containing a base64‑encoded service account JSON. Start the server:
    ```bash
    npm start
    ```
@@ -33,7 +33,7 @@ When the frontend loads it attempts to use the backend via `DataService`. If the
 
 ## Development Notes
 
-- The server keeps its data in `server/data.json`. It is loaded on startup and saved whenever changes occur.
+- The server keeps its data in Firestore and mirrors it in memory. Changes made directly in Firestore are watched and broadcast to connected clients.
 - Static files are served from the `shopping-list-app` directory.
 - WebSocket updates are broadcast using Socket.IO on every data change.
 - The client code lives in `shopping-list-app/script.js` and uses `dataService.js` to abstract storage.

--- a/server/db.js
+++ b/server/db.js
@@ -15,10 +15,24 @@ async function loadCollection(name) {
   return snapshot.docs.map(doc => doc.data());
 }
 
-async function clearCollection(name) {
-  const snapshot = await db.collection(name).get();
+// Replace the entire collection in a single batch so snapshot listeners
+// don't observe a momentary empty state during updates.
+async function saveCollection(name, items) {
+  const coll = db.collection(name);
+  const snapshot = await coll.get();
   const batch = db.batch();
-  snapshot.docs.forEach(doc => batch.delete(doc.ref));
+  const newIds = new Set(items.map(i => i.id));
+
+  snapshot.docs.forEach(doc => {
+    if (!newIds.has(doc.id)) {
+      batch.delete(doc.ref);
+    }
+  });
+
+  items.forEach(item => {
+    batch.set(coll.doc(item.id), item);
+  });
+
   await batch.commit();
 }
 
@@ -33,32 +47,13 @@ async function loadData() {
 }
 
 async function saveData(data) {
-  // Clear existing documents
   await Promise.all([
-    clearCollection('lists'),
-    clearCollection('items'),
-    clearCollection('categories'),
-    clearCollection('archivedLists'),
-    clearCollection('receipts')
+    saveCollection('lists', data.lists),
+    saveCollection('items', data.globalItems),
+    saveCollection('categories', data.categories),
+    saveCollection('archivedLists', data.archivedLists),
+    saveCollection('receipts', data.receipts)
   ]);
-
-  const batch = db.batch();
-  data.lists.forEach(item =>
-    batch.set(db.collection('lists').doc(item.id), item)
-  );
-  data.globalItems.forEach(item =>
-    batch.set(db.collection('items').doc(item.id), item)
-  );
-  data.categories.forEach(item =>
-    batch.set(db.collection('categories').doc(item.id), item)
-  );
-  data.archivedLists.forEach(item =>
-    batch.set(db.collection('archivedLists').doc(item.id), item)
-  );
-  data.receipts.forEach(item =>
-    batch.set(db.collection('receipts').doc(item.id), item)
-  );
-  await batch.commit();
 }
 
 function watchCollection(collection, key, onChange) {


### PR DESCRIPTION
## Summary
- listen to Firestore changes and refresh in-memory cache
- log and skip corrupted Firestore documents
- document Firestore usage and credentials

## Testing
- `npm start` *(fails: The first argument must be of type string or Buffer. Received undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6892181f9a208325bb3b1edfd1282f3d