### PR TITLE
Fix overlay modals hidden by Bootstrap styles

### DIFF
--- a/shopping-list-app/style.css
+++ b/shopping-list-app/style.css
@@ -152,6 +152,9 @@ nav button.active {
     box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
     max-height: 90vh;
     overflow-y: auto;
+    /* Override Bootstrap's default modal styles */
+    display: block;
+    position: relative;
 }
 
 #modal-overlay,


### PR DESCRIPTION
## Summary
- Ensure custom modals are visible by overriding Bootstrap's default `.modal` display and positioning

## Testing
- `npm install`
- `FIREBASE_SERVICE_ACCOUNT_JSON=$(printf '{}' | base64) npm start` *(fails: Service account object must contain a string "project_id" property)*

------
https://chatgpt.com/codex/tasks/task_e_68933527d29083259eb07fc4ad2057e1