### PR TITLE
feat: batch server saves and use sockets for updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ When the frontend loads it attempts to use the backend via `DataService`. If the
 - WebSocket updates are broadcast using Socket.IO on every data change.
 - The client code lives in `shopping-list-app/script.js` and uses `dataService.js` to abstract storage.
 
+## Firestore Writes
+
+To reduce Firestore write volume during rapid edits, the server batches
+changes in memory and flushes them to Firestore every few seconds.
+Clients send updates primarily over WebSockets which keeps the in‑memory
+state authoritative while avoiding excessive REST calls.
+
 ## Clearing Data
 
 Send a POST request to `/data/clear` or use the "Clear All Data" button in the Settings page to reset the stored data.


### PR DESCRIPTION
## Summary
- debounce Firestore writes on the server so rapid edits are batched
- send client updates over WebSocket and clear data via socket events
- allow server to run without Firestore credentials and document batching in README

## Testing
- `cd server && npm start >/tmp/server.log 2>&1 &`
- `tail -n 20 /tmp/server.log`
- `kill 4280`


------
https://chatgpt.com/codex/tasks/task_e_6895b62ca9688325b689d399fb75cd18