### PR TITLE
Batch Firebase writes and ack socket operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ When the frontend loads it attempts to use the backend via `DataService`. If the
 - Revision tracking on the server with a client‑side save queue reduces conflicts when multiple users edit simultaneously.
 - Client changes are applied instantly and sent in debounced batches with unique IDs, allowing each client to ignore its own echoed updates.
  - The client keeps track of the latest revision and drops out‑of‑date socket events so rapid edits aren’t overwritten by stale data.
+- Firebase writes are batched on the server and flushed periodically to minimise backend churn.
+- Real‑time socket operations require acknowledgements, ensuring each change is applied in order before sending the next.
 
 ## Development Notes
 


### PR DESCRIPTION
## Summary
- Batch in-memory changes before persisting to Firebase and flush periodically
- Acknowledge socket operations and send them sequentially from clients
- Document batched writes and operation acknowledgements

## Testing
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68962a088c04832591c8845617f5c8e3